### PR TITLE
feat: Implement optional logging

### DIFF
--- a/lib/selective-ruby-core.rb
+++ b/lib/selective-ruby-core.rb
@@ -24,6 +24,7 @@ module Selective
       class Init
         def initialize(args)
           @debug = !args.delete("--debug").nil?
+          @log = !args.delete("--log").nil?
           @runner_name, @args, @command = parse_args(args)
           require_runner
         end
@@ -34,10 +35,10 @@ module Selective
 
         private
 
-        attr_reader :debug, :runner_name, :args, :command
+        attr_reader :debug, :log, :runner_name, :args, :command
 
         def run
-          Selective::Ruby::Core::Controller.new(runner, debug).send(command)
+          Selective::Ruby::Core::Controller.new(runner, debug: debug, log: log).send(command)
         end
 
         def parse_args(args)

--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -1,6 +1,7 @@
 require "logger"
 require "uri"
 require "json"
+require 'fileutils'
 
 module Selective
   module Ruby
@@ -8,12 +9,12 @@ module Selective
       class Controller
         @@selective_suppress_reporting = false
 
-        def initialize(runner, debug = false)
+        def initialize(runner, debug: false, log: false)
           @debug = debug
           @runner = runner
           @retries = 0
           @runner_id = ENV.fetch("SELECTIVE_RUNNER_ID", generate_runner_id)
-          @logger = Logger.new("log/#{runner_id}.log")
+          @logger = init_logger(log)
         end
 
         def start(reconnect: false)
@@ -51,6 +52,15 @@ module Selective
         attr_reader :runner, :pipe, :transport_pid, :retries, :logger, :runner_id
 
         BUILD_ENV_SCRIPT_PATH = "../../../bin/build_env.sh".freeze
+
+        def init_logger(enabled)
+          if enabled
+            FileUtils.mkdir_p("log")
+            Logger.new("log/#{runner_id}.log")
+          else
+            Logger.new("/dev/null")
+          end
+        end
 
         def run_main_loop
           loop do

--- a/spec/selective/ruby/core/init_spec.rb
+++ b/spec/selective/ruby/core/init_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[exec mock_runner] }
 
       it "initializes runner and calls exec" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, false)
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: false, log: false)
         expect(mock_runner_class).to have_received(:new).with([])
         expect(mock_controller).to have_received(:exec)
       end
@@ -24,7 +24,7 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[exec mock_runner --dry-run] }
 
       it "initializes runner with the --dry-run option and calls exec" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, false)
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: false, log: false)
         expect(mock_runner_class).to have_received(:new).with(["--dry-run"])
         expect(mock_controller).to have_received(:exec)
       end
@@ -34,7 +34,7 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[mock_runner] }
 
       it "initializes runner and calls start" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, false)
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: false, log: false)
         expect(mock_runner_class).to have_received(:new).with([])
         expect(mock_controller).to have_received(:start)
       end
@@ -44,7 +44,17 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[mock_runner --debug] }
 
       it "initializes runner with debug and calls start" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, true)
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: true, log: false)
+        expect(mock_runner_class).to have_received(:new).with([])
+        expect(mock_controller).to have_received(:start)
+      end
+    end
+
+    context "with 'selective mock_runner --log'" do
+      let(:args) { %w[mock_runner --log] }
+
+      it "initializes runner with debug and calls start" do
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: false, log: true)
         expect(mock_runner_class).to have_received(:new).with([])
         expect(mock_controller).to have_received(:start)
       end
@@ -54,7 +64,7 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[mock_runner spec/foo/bar_spec.rb] }
 
       it "initializes runner with file path and calls start" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, false)
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: false, log: false)
         expect(mock_runner_class).to have_received(:new).with(["spec/foo/bar_spec.rb"])
         expect(mock_controller).to have_received(:start)
       end


### PR DESCRIPTION
Logging wasn't optional before this change. Now we disable logging by default and enable it with the `--log` flag. We've also handled the scenario where the log directory doesn't exist. It'll create the log dir when needed.