### PR TITLE
Implement print_notice

### DIFF
--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -187,8 +187,8 @@ module Selective
 
         def handle_command(response)
           case response[:command]
-          when "init"
-            print_init(response[:runner_id])
+          when "print_notice"
+            print_notice(response[:message])
           when "test_manifest"
             handle_test_manifest
           when "run_test_cases"
@@ -201,10 +201,11 @@ module Selective
             handle_print_message(response[:message])
           when "close"
             handle_close(response[:exit_status])
-
-            # This is here for the sake of test where we
-            # cannot exit but we need to break the loop
+            # This return is here for the sake of test where
+            # we cannot exit but we need to break the loop
             return false
+          else
+            raise "Unknown command received: #{response[:command]}" if debug?
           end
 
           true
@@ -299,10 +300,10 @@ module Selective
           TEXT
         end
 
-        def print_init(runner_id)
+        def print_notice(message)
           puts_indented <<~TEXT
             #{banner}
-            Runner ID: #{runner_id.gsub("selgen-", "")}
+            #{message}
           TEXT
         end
 

--- a/spec/selective/ruby/core/controller_spec.rb
+++ b/spec/selective/ruby/core/controller_spec.rb
@@ -15,16 +15,18 @@ RSpec.describe Selective::Ruby::Core::Controller do
 
   describe "#start" do
     before do
-      allow(controller).to receive(:print_init)
+      allow(controller).to receive(:print_notice)
       allow(described_class).to receive(:restore_reporting!)
     end
 
     it "processes commands" do
+      message = "Hello World"
+
       send_commands(controller, [
-        {command: "init", runner_id: controller.runner_id}
+        {command: "print_notice", message: message}
       ])
 
-      expect(controller).to have_received(:print_init).once.with(controller.runner_id)
+      expect(controller).to have_received(:print_notice).once.with(message)
       expect(runner).to have_received(:finish).once
     end
 


### PR DESCRIPTION
This is a change we can make while we're in limited alpha. In the future we'll want to make this change in a way that is backwards compatible.

With that in mind we've also added an else condition that will raise an error if we receive an unknown command, but only if debug is enabled.