### PR TITLE
Update base_url in get_transport script

### DIFF
--- a/bin/get_transport
+++ b/bin/get_transport
@@ -10,7 +10,7 @@ arch=${2:-$(uname -m)}
 [ "$os" = "Darwin" ] && [ "$arch" = "arm64" ] && arch="aarch64"
 
 # Define base URL
-base_url="https://github.com/selectiveci/transport/releases/download/latest/transport"
+base_url="https://github.com/selectiveci/transport/releases/latest/download/transport"
 
 # Construct download URL
 url="${base_url}-${os}-${arch}.tar.gz"


### PR DESCRIPTION
We're using GitHub's "latest" release feature now.