### PR TITLE
Get run id and attempt from build env

### DIFF
--- a/lib/bin/build_env.sh
+++ b/lib/bin/build_env.sh
@@ -9,6 +9,8 @@ if [ -n "$GITHUB_ACTIONS" ]; then
   target_branch=${GITHUB_BASE_REF}
   actor=$GITHUB_ACTOR
   sha=$GITHUB_SHA
+  run_id=$GITHUB_RUN_ID
+  run_attempt=$GITHUB_RUN_ATTEMPT
   commit_message=$(git log --format=%s -n 1 $sha)
 else
   platform=$SELECTIVE_PLATFORM
@@ -17,6 +19,8 @@ else
   target_branch=$SELECTIVE_TARGET_BRANCH
   actor=$SELECTIVE_ACTOR
   sha=$SELECTIVE_SHA
+  run_id=$SELECTIVE_RUN_ID
+  run_attempt=$SELECTIVE_RUN_ATTEMPT
   commit_message=$(git log --format=%s -n 1 $sha)
 fi
 
@@ -29,6 +33,8 @@ cat <<EOF
     "target_branch": "$target_branch",
     "actor": "$actor",
     "sha": "$sha",
+    "run_id": "$run_id",
+    "run_attempt": "$run_attempt",
     "commit_message": "$commit_message"
   }
 EOF

--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -101,12 +101,14 @@ module Selective
         def transport_url
           @transport_url ||= begin
             api_key = ENV.fetch("SELECTIVE_API_KEY")
-            run_id = ENV.fetch("SELECTIVE_RUN_ID")
-            run_attempt = ENV.fetch("SELECTIVE_RUN_ATTEMPT", SecureRandom.uuid)
             host = ENV.fetch("SELECTIVE_HOST", "wss://app.selective.ci")
 
             # Validate that host is a valid websocket url(starts with ws:// or wss://)
             raise "Invalid host: #{host}" unless host.match?(/^wss?:\/\//)
+
+            run_id = build_env.delete("run_id")
+            run_attempt = build_env.delete("run_attempt")
+            run_attempt = SecureRandom.uuid if run_attempt.nil? || run_attempt.empty?
 
             params = {
               "run_id" => run_id,


### PR DESCRIPTION
These values are sometimes available in the build env and as such we should attempt to use them. If they are not available, we can generate a default where necessary.

The build env code is due for a refactor, but this is a quick fix to get the values we need.