### PR TITLE
Ensure runner id is safe for filenames & implement wait_for_connectivity

### DIFF
--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -199,7 +199,7 @@ module Selective
 
               sleep(1)
             end
-          rescue NamedPipe::PipeClosedError
+          rescue NamedPipe::PipeClosedError, IOError
             # If the pipe is close, move straight to killing
             # it forcefully.
           end

--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -160,7 +160,7 @@ module Selective
             unless @connectivity
               puts "Transport process failed to start. Exiting..."
               kill_transport
-              exit
+              exit(1)
             end
           end
 

--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -157,11 +157,11 @@ module Selective
 
           Thread.new do
             sleep(5)
-            return if @connectivity
-
-            puts "Transport process failed to start. Exiting..."
-            kill_transport
-            exit
+            unless @connectivity
+              puts "Transport process failed to start. Exiting..."
+              kill_transport
+              exit
+            end
           end
 
           loop do

--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -14,7 +14,7 @@ module Selective
           @debug = debug
           @runner = runner
           @retries = 0
-          @runner_id = ENV.fetch("SELECTIVE_RUNNER_ID", generate_runner_id)
+          @runner_id = safe_filename(ENV.fetch("SELECTIVE_RUNNER_ID", generate_runner_id))
           @logger = init_logger(log)
         end
 
@@ -23,6 +23,7 @@ module Selective
           @transport_pid = spawn_transport_process(reconnect ? transport_url + "&reconnect=true" : transport_url)
 
           handle_termination_signals(transport_pid)
+          wait_for_connectivity
           run_main_loop
         rescue NamedPipe::PipeClosedError
           retry!
@@ -66,8 +67,6 @@ module Selective
         def run_main_loop
           loop do
             message = pipe.read
-            next sleep(0.1) if message.nil? || message.empty?
-
             response = JSON.parse(message, symbolize_names: true)
 
             @logger.info("Received Command: #{response}")
@@ -150,6 +149,31 @@ module Selective
 
           Process.spawn(transport_path, url, runner_id).tap do |pid|
             Process.detach(pid)
+          end
+        end
+
+        def wait_for_connectivity
+          @connectivity = false
+
+          Thread.new do
+            sleep(5)
+            return if @connectivity
+
+            puts "Transport process failed to start. Exiting..."
+            kill_transport
+            exit
+          end
+
+          loop do
+            message = pipe.read
+
+            # The message is nil until the transport opens the pipe
+            # for writing. So, we must handle that here.
+            next sleep(0.1) if message.nil?
+            
+            response = JSON.parse(message, symbolize_names: true)
+            @connectivity = true if response[:command] == "connected"
+            break
           end
         end
 
@@ -270,6 +294,13 @@ module Selective
 
         def debug?
           @debug
+        end
+
+        def safe_filename(filename)
+          filename
+            .gsub(/[\/\\:*?"<>|\n\r]+/, '_')
+            .gsub(/^\.+|\.+$/, '')
+            .strip[0, 255]
         end
 
         def with_error_handling(include_header: true)

--- a/spec/selective/ruby/core/controller_spec.rb
+++ b/spec/selective/ruby/core/controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Selective::Ruby::Core::Controller do
   before do
     allow(Process).to receive(:spawn).and_return(123)
     allow(controller).to receive(:handle_termination_signals)
+    allow(controller).to receive(:wait_for_connectivity)
     allow(controller).to receive(:exit)
   end
 


### PR DESCRIPTION
We discovered a scenario where things would hang if the transport crashed before it could open the write pipe. This commit adds a wait_for_connectivity method that will wait for the transport to open the pipe for writing. If it doesn't happen within 5 seconds, the controller will exit.

We also discovered that the runner id could contain characters that are not allowed in filenames. This commit adds a safe_filename method that will strip out any characters that are not allowed in filenames.