### PR TITLE
Increase failed startup wait time from 5 -> 30 seconds

### DIFF
--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -156,7 +156,7 @@ module Selective
           @connectivity = false
 
           Thread.new do
-            sleep(5)
+            sleep(30)
             unless @connectivity
               puts "Transport process failed to start. Exiting..."
               kill_transport


### PR DESCRIPTION
We've seen edgecases where it can take a while for the connection to be made. What we really want here is to ensure that a node doesn't hang forever. So, a 30 second timeout is fine.