### PR TITLE
Ignore version file to prevent zeitwerk eagerload issue

### DIFF
--- a/lib/selective-ruby-core.rb
+++ b/lib/selective-ruby-core.rb
@@ -4,6 +4,7 @@ require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
 loader.ignore("#{__dir__}/selective-ruby-core.rb")
+loader.ignore("#{__dir__}/selective/ruby/core/version.rb")
 loader.setup
 
 module Selective


### PR DESCRIPTION
The version file doesn't define a Version constant. It defines a VERSION constant, which is typical for a rubygem. To avoid this issue we're explicitly ignoring the version file.

> expected file lib/selective/ruby/core/version.rb to define constant
> Selective::Ruby::Core::Version, but didn't