### PR TITLE
Send version information in connection parameters

### DIFF
--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -111,7 +111,12 @@ module Selective
               "run_id" => run_id,
               "run_attempt" => run_attempt,
               "api_key" => api_key,
-              "runner_id" => runner_id
+              "runner_id" => runner_id,
+              "language" => "ruby",
+              "core_version" => Selective::Ruby::Core::VERSION,
+              "framework" => runner.framework,
+              "framework_version" => runner.framework_version,
+              "framework_wrapper_version" => runner.wrapper_version,
             }.merge(metadata: build_env.to_json)
 
             prams[:reconnect] = true if reconnect

--- a/spec/selective/ruby/core/controller_spec.rb
+++ b/spec/selective/ruby/core/controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Selective::Ruby::Core::Controller do
-  let(:runner) { double("runner", finish: nil, exit_status: 1) }
+  let(:runner) { double("runner", finish: nil, exit_status: 1, framework: 'rspec', framework_version: "1.0", wrapper_version: "1.0") }
   let(:controller) { dirty_dirty_unprivate_class(described_class).new(runner) }
 
   let!(:pipe) { Selective::Ruby::Core::NamedPipe.new("/tmp/#{controller.runner_id}_test_2", "/tmp/#{controller.runner_id}_test_1", skip_reset: true) }


### PR DESCRIPTION
>[!WARNING]
> This requires a change in the `selective-ruby-rspec` gem, which is not yet released: https://github.com/selectiveci/selective-ruby-rspec/pull/14. The specs here will fail until that is merged.

Unfortunately we can't use the gemspec to ensure that a new version of the core gem which includes this change cannot be used with an older version of `selective-ruby-rspec` that does not have the dependent methods (such as `#framework`). This is because it's `selective-ruby-rspec` that has a dependency on core, not the other way around.

Given that we're in the alpha testing stage with limited users, we may get away with just releasing both gems and expecting both gems to be updated when testers `bundle update selective-ruby-rspec`. However, this won't be a great idea in the future when we have a more diverse install-base . The best we could do is implement changes like this in a compatible way. For example, do not add the new information if the framework wrapper gem (`selective-ruby-rspec`) doesn't have the methods we need.