### PR TITLE
Explicitly require version file

### DIFF
--- a/lib/selective-ruby-core.rb
+++ b/lib/selective-ruby-core.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "zeitwerk"
+require "#{__dir__}/selective/ruby/core/version"
 
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
 loader.ignore("#{__dir__}/selective-ruby-core.rb")


### PR DESCRIPTION
Minor bugfix. In certain scenarios we need to explicitly require the version file since it doesn't follow zeitwerk conventions.