### PR TITLE
Implement test file correlation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
       matrix:
         ci_node_total: [4]
         ci_node_index: [0, 1, 2, 3]
+    env:
+      SELECTIVE_HOST: wss://staging.selective.ci
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           runner-id: ${{ matrix.ci_node_index }}
 
       - name: Run the default task
-        run: bundle exec selective rspec
+        run: bundle exec selective rspec --log
 
       - name: Store logs
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,6 @@ jobs:
       matrix:
         ci_node_total: [4]
         ci_node_index: [0, 1, 2, 3]
-    env:
-      SELECTIVE_HOST: wss://staging.selective.ci
 
     steps:
       - uses: actions/checkout@v3

--- a/lib/bin/file_correlation_collector.sh
+++ b/lib/bin/file_correlation_collector.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+# The first argument is the number of commits to process
+branch=$1
+num_commits=$2
+
+# Initialize an associative array to hold the files to check
+declare -A files_to_check
+
+# Populate the array with the script arguments, starting from the second argument
+for file in "${@:3}"
+do
+  files_to_check["$file"]=1
+done
+
+# Get a list of all commit hashes, in reverse order
+all_commits=$(git log origin/$branch --no-merges --format=%H --reverse -n $num_commits)
+
+# Initialize an associative array to store the test files
+declare -A test_files
+declare -A uncorrelated_test_files
+
+# Initialize an array to store the files changed in the previous commit
+prev_changed_files=()
+
+# For each commit...
+for commit in $all_commits
+do
+  # Get a list of all files that were changed in the current commit
+  files=$(git diff-tree --no-commit-id --name-only -r $commit)
+
+  declare -A correlated_test_files
+
+  # # For each file in the list of files changed in the previous commit...
+  for file in "${prev_changed_files[@]}"
+  do
+    # If the file is in the list of files to check...
+    if [[ ${files_to_check[$file]} ]]; then
+      # For each file...
+      for test_file in $files
+      do
+        # If the file is in the test/ directory and ends with _test.rb...
+        if [[ $test_file == spec/*_spec.rb ]]
+        then
+          # Increment the count in the associative array
+          test_files["$file|$test_file"]=$((test_files["$file|$test_file"]+1))
+          # Add the test file to the correlated_test_files array
+          correlated_test_files["$test_file"]=1
+        fi
+      done
+    fi
+  done
+
+  # For each file in the list of files changed in the current commit...
+  for file in $files
+  do
+    # If the file is in the list of files to check...
+    if [[ ${files_to_check[$file]} ]]; then
+      # For each file...
+      for test_file in $files
+      do
+        # If the file is in the test/ directory and ends with _test.rb...
+        if [[ $test_file == spec/*_spec.rb ]]
+        then
+          # Increment the count in the associative array
+          test_files["$file|$test_file"]=$((test_files["$file|$test_file"]+1))
+          # Add the test file to the correlated_test_files array
+          correlated_test_files["$test_file"]=1
+        fi
+      done
+    fi
+  done
+
+  # For each file...
+  for test_file in $files
+  do
+    # If the file is in the test/ directory and ends with _test.rb...
+    if [[ $test_file == spec/*_spec.rb ]]
+    then
+      # If the test file is not correlated to any of the files to check in the current commit...
+      if [[ -z ${correlated_test_files[$test_file]} ]]
+      then
+        # Increment the count in the associative array
+        uncorrelated_test_files["$test_file"]=$((uncorrelated_test_files["$test_file"]+1))
+      fi
+    fi
+  done
+
+  # Clear the correlated_test_files array for the next commit
+  unset correlated_test_files
+
+  # Store the list of files changed in this commit for the next iteration
+  prev_changed_files=($files)
+done
+
+# OUTPUT
+
+# Initialize an associative array to hold the JSON strings for each file
+declare -A file_jsons
+
+# Add the test_files to the file_jsons associative array
+for key in "${!test_files[@]}"
+do
+  file=${key%|*}
+  test_file=${key#*|}
+  count=${test_files[$key]}
+  # Append to the JSON string for this file
+  file_jsons["$file"]+="\"$test_file\": $count,"
+done
+
+# Initialize an empty string for the test_files JSON
+correlated_files_json=""
+
+# Add the file_jsons to the correlated_files_json string
+for file in "${!file_jsons[@]}"
+do
+  # Remove the trailing comma from the JSON string for this file
+  file_json=${file_jsons[$file]%?}
+  # Append to the correlated_files_json string
+  correlated_files_json+="\"$file\": { $file_json },"
+done
+
+# Remove the trailing comma from the correlated_files_json string
+correlated_files_json=${correlated_files_json%?}
+
+# Initialize an empty string for the uncorrelated_test_files JSON
+uncorrelated_files_json=""
+
+# Add the uncorrelated_test_files to the uncorrelated_files_json string
+for key in "${!uncorrelated_test_files[@]}"
+do
+  count=${uncorrelated_test_files[$key]}
+  # Append to the uncorrelated_files_json string
+  uncorrelated_files_json+="\"$key\": $count,"
+done
+
+# Remove the trailing comma from the uncorrelated_files_json string
+uncorrelated_files_json=${uncorrelated_files_json%?}
+
+# Output the JSON
+echo "{ \"correlated_files\": { $correlated_files_json }, \"uncorrelated_files\": { $uncorrelated_files_json } }"

--- a/lib/selective-ruby-core.rb
+++ b/lib/selective-ruby-core.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "zeitwerk"
+require "json"
+require "open3"
 require "#{__dir__}/selective/ruby/core/version"
 
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)

--- a/lib/selective-ruby-core.rb
+++ b/lib/selective-ruby-core.rb
@@ -13,6 +13,8 @@ module Selective
     module Core
       class Error < StandardError; end
 
+      ROOT_GEM_PATH = Gem.loaded_specs["selective-ruby-core"].full_gem_path
+
       @@available_runners = {}
 
       def self.register_runner(name, runner_class)

--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -1,8 +1,6 @@
 require "logger"
 require "uri"
-require "json"
 require "fileutils"
-require "open3"
 
 module Selective
   module Ruby

--- a/lib/selective/ruby/core/file_correlator.rb
+++ b/lib/selective/ruby/core/file_correlator.rb
@@ -8,14 +8,13 @@ module Selective
 
         FILE_CORRELATION_COLLECTOR_PATH = File.join(ROOT_GEM_PATH, "lib", "bin", "file_correlation_collector.sh")
 
-        def initialize(data, diff, target_branch)
-          @num_commits = data[:num_commits] || 1000
+        def initialize(diff, num_commits, target_branch)
           @diff = diff
+          @num_commits = num_commits
           @target_branch = target_branch
         end
 
         def correlate
-          fetch_target_branch
           JSON.parse(get_correlated_files, symbolize_names: true)
         rescue FileCorrelatorError, JSON::ParserError
           print_warning "Selective was unable to correlate the diff to test files. This may result in a sub-optimal test order. If the issue persists, please contact support."
@@ -23,13 +22,7 @@ module Selective
 
         private
 
-        attr_reader :num_commits, :target_branch, :diff
-
-        def fetch_target_branch
-          Open3.capture2e("git fetch origin #{target_branch} --depth=#{num_commits}").tap do |_, status|
-            raise FileCorrelatorError unless status.success?
-          end
-        end
+        attr_reader :diff, :num_commits, :target_branch
 
         def get_correlated_files
           Open3.capture2e("#{FILE_CORRELATION_COLLECTOR_PATH} #{target_branch} #{num_commits} #{diff.join(" ")}").then do |output, status|

--- a/lib/selective/ruby/core/file_correlator.rb
+++ b/lib/selective/ruby/core/file_correlator.rb
@@ -1,0 +1,45 @@
+module Selective
+  module Ruby
+    module Core
+      class FileCorrelator
+        include Helper
+
+        class FileCorrelatorError < StandardError; end
+
+        FILE_CORRELATION_COLLECTOR_PATH = File.join(ROOT_GEM_PATH, "lib", "bin", "file_correlation_collector.sh")
+
+        def initialize(data, diff, target_branch)
+          @num_commits = data[:num_commits] || 1000
+          @diff = diff
+          @target_branch = target_branch
+        end
+
+        def correlate
+          fetch_target_branch
+          JSON.parse(get_correlated_files, symbolize_names: true)
+        rescue FileCorrelatorError, JSON::ParserError
+          print_warning "Selective was unable to correlate the diff to test files. This may result in a sub-optimal test order. If the issue persists, please contact support."
+        end
+
+        private
+
+        attr_reader :num_commits, :target_branch, :diff
+
+        def fetch_target_branch
+          Open3.capture2e("git fetch origin #{target_branch} --depth=#{num_commits}").tap do |_, status|
+            raise FileCorrelatorError unless status.success?
+          end
+        end
+
+        def get_correlated_files
+          Open3.capture2e("#{FILE_CORRELATION_COLLECTOR_PATH} #{target_branch} #{num_commits} #{diff.join(" ")}").then do |output, status|
+
+            raise FileCorrelatorError unless status.success?
+
+            output
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/selective/ruby/core/helper.rb
+++ b/lib/selective/ruby/core/helper.rb
@@ -1,0 +1,76 @@
+module Selective
+  module Ruby
+    module Core
+      module Helper
+        def safe_filename(filename)
+          filename
+            .gsub(/[\/\\:*?"<>|\n\r]+/, '_')
+            .gsub(/^\.+|\.+$/, '')
+            .strip[0, 255]
+        end
+
+        def with_error_handling(include_header: true)
+          yield
+        rescue => e
+          raise e if debug?
+          header = <<~TEXT
+            An error occurred. Please rerun with --debug
+            and contact support at https://selective.ci/support
+          TEXT
+
+          unless $selective_banner_displayed
+            header = <<~TEXT
+              #{banner}
+
+              #{header}
+            TEXT
+          end
+
+          puts_indented <<~TEXT
+            \e[31m
+            #{header if include_header}
+            #{e.message}
+            \e[0m
+          TEXT
+
+          exit 1
+        end
+
+        def print_warning(message)
+          puts_indented <<~TEXT
+            \e[33m
+            #{message}
+            \e[0m
+          TEXT
+        end
+
+        def print_notice(message)
+          puts_indented <<~TEXT
+            #{banner unless $selective_banner_displayed}
+            #{message}
+          TEXT
+        end
+
+        def puts_indented(text)
+          puts text.gsub(/^/, "  ")
+        end
+
+        def banner
+          Helper.banner
+        end
+
+        def self.banner
+          $selective_banner_displayed = true
+          <<~BANNER
+             ____       _           _   _
+            / ___|  ___| | ___  ___| |_(_)_   _____
+            \\___ \\ / _ \\ |/ _ \\/ __| __| \\ \\ / / _ \\
+             ___) |  __/ |  __/ (__| |_| |\\ V /  __/
+            |____/ \\___|_|\\___|\\___|\\__|_| \\_/ \\___|
+            ________________________________________
+          BANNER
+        end
+      end
+    end
+  end
+end

--- a/spec/selective/ruby/core/file_correlator_spec.rb
+++ b/spec/selective/ruby/core/file_correlator_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Selective::Ruby::Core::FileCorrelator do
+  let(:instance) { described_class.new({}, [], target_branch) }
+  let(:target_branch) { "main" }
+
+  describe "#correlate" do
+    it "returns a hash with the expected shape" do
+      expect(instance.correlate).to match({:correlated_files => Hash, :uncorrelated_files => Hash})
+    end
+
+    context 'when an error occurs' do
+      let(:target_branch) { "unknown-branch" }
+
+      it "warns and returns nil" do
+        expect(instance).to receive(:print_warning).with(/please contact support/)
+        expect(instance.correlate).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/selective/ruby/core/file_correlator_spec.rb
+++ b/spec/selective/ruby/core/file_correlator_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Selective::Ruby::Core::FileCorrelator do
-  let(:instance) { described_class.new({}, [], target_branch) }
+  let(:instance) { described_class.new([], 1, target_branch) }
   let(:target_branch) { "main" }
 
   describe "#correlate" do


### PR DESCRIPTION
This PR implements a method of correlating files from the diff to test files based on how they have changed together over the history of the project. The raw information (only file names) is sent to the backend where we use an algorithm determine the probability of correlation. We then use this information to order the tests such that the tests which are correlated to files in the diff are run first.

Doing this requires a target branch, so it'll only happen in the PR scenario, and only if the target branch is provided to selective. We fetch 1000 commits on the target branch by default, but this will be configurable via the selective dashboard in the future.