### PR TITLE
Add committer name and email to build_env

### DIFF
--- a/lib/bin/build_env.sh
+++ b/lib/bin/build_env.sh
@@ -44,6 +44,8 @@ cat <<EOF
     "run_id": "$run_id",
     "run_attempt": "$run_attempt",
     "commit_message": "$(git log --format=%s -n 1 $sha)",
-    "runner_id": "$runner_id"
+    "runner_id": "$runner_id",
+    "committer_name": "$(git show -s --format='%an' -n 1 $sha)",
+    "committer_email": "$(git show -s --format='%ae' -n 1 $sha)"
   }
 EOF


### PR DESCRIPTION
If an actor is not available, we can fall back to using the committer name in the UI.