### PR TITLE
Set a static run_attempt for Semaphore

### DIFF
--- a/lib/bin/build_env.sh
+++ b/lib/bin/build_env.sh
@@ -26,6 +26,7 @@ elif [ -n "$SEMAPHORE" ]; then
   actor=$SEMAPHORE_GIT_COMMITTER
   sha=$SEMAPHORE_GIT_SHA
   run_id=$SEMAPHORE_WORKFLOW_ID
+  run_attempt=1
   runner_id=$SEMAPHORE_JOB_ID
   pr_title=$SEMAPHORE_GIT_PR_NAME
 fi


### PR DESCRIPTION
On Semaphore, hitting the rerun button generates an entirely new build with a unique job id, workflow id, and pipeline id. As such, we don't have anything to group it by in order to tell if it is a rerun or not.

Initially I figured I'd leave the run_attempt blank since we generate one if it isn't set. But, then we have the problem were a straggler node can restart a build if it comes online after the build has finished.

With this in mind, I think it's better to explicitly set a static run_attempt for Semaphore since each build is a one-shot.

As an aside, perhaps we should consider ditching our auto-generated after all.