### PR TITLE
Require Run Attempt

### DIFF
--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -14,6 +14,7 @@ module Selective
           "api_key" => "SELECTIVE_API_KEY",
           "platform" => "SELECTIVE_PLATFORM",
           "run_id" => "SELECTIVE_RUN_ID",
+          "run_attempt" => "SELECTIVE_RUN_ATTEMPT",
           "branch" => "SELECTIVE_BRANCH"
         }.freeze
 
@@ -113,7 +114,6 @@ module Selective
             host = build_env.delete("host")
             run_id = build_env.delete("run_id")
             run_attempt = build_env.delete("run_attempt")
-            run_attempt = SecureRandom.uuid if run_attempt.nil? || run_attempt.empty?
 
             params = {
               "run_id" => run_id,

--- a/spec/selective/ruby/core/file_correlator_spec.rb
+++ b/spec/selective/ruby/core/file_correlator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Selective::Ruby::Core::FileCorrelator do
       # but if another runner created the manifest the fetch may
       # not have happened on the runner that is running this test.
       # So, we fetch here to ensure this test ddoes not fail.
-      `git fetch origin #{target_branch} --depth=1`
+      Open3.capture2e("git fetch origin #{target_branch} --depth=1")
       expect(instance.correlate).to match({:correlated_files => Hash, :uncorrelated_files => Hash})
     end
 


### PR DESCRIPTION
Previously we allowed run attempt to be empty and in that case we would generate a UUID. This isn't really viable outside of a test scenario so we're going to require it to be set.