### PR TITLE
Pass test case callback to runner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,5 @@ gem "simplecov", require: false, group: :test
 if Dir.exist?(selective_ruby_rspec_path = "../selective-ruby-rspec")
   gem "selective-ruby-rspec", path: selective_ruby_rspec_path
 else
-  gem "selective-ruby-rspec", git: "https://#{ENV["CLONE_PAT"]}:@github.com/selectiveci/selective-ruby-rspec.git"
+  gem "selective-ruby-rspec", git: "https://github.com/selectiveci/selective-ruby-rspec.git", branch: "give-batches-to-rspec"
 end

--- a/lib/selective-ruby-core.rb
+++ b/lib/selective-ruby-core.rb
@@ -44,7 +44,7 @@ module Selective
         attr_reader :debug, :log, :runner_name, :args, :command
 
         def run
-          Selective::Ruby::Core::Controller.new(runner, debug: debug, log: log).send(command)
+          Selective::Ruby::Core::Controller.new(runner_class, args, debug: debug, log: log).send(command)
         end
 
         def parse_args(args)
@@ -56,8 +56,8 @@ module Selective
           end
         end
 
-        def runner
-          Selective::Ruby::Core.runner_for(runner_name).new(args)
+        def runner_class
+          Selective::Ruby::Core.runner_for(runner_name)
         end
 
         def require_runner

--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -17,9 +17,9 @@ module Selective
           "branch" => "SELECTIVE_BRANCH"
         }.freeze
 
-        def initialize(runner, debug: false, log: false)
+        def initialize(runner_class, runner_args, debug: false, log: false)
           @debug = debug
-          @runner = runner
+          @runner = runner_class.new(runner_args, method(:test_case_callback))
           @retries = 0
           @runner_id = safe_filename(get_runner_id)
           @logger = init_logger(log)
@@ -267,7 +267,7 @@ module Selective
         end
 
         def handle_run_test_cases(data)
-          runner.run_test_cases(data[:test_case_ids], method(:test_case_callback))
+          runner.run_test_cases(data[:test_case_ids])
         end
 
         def handle_remove_failed_test_case_result(data)

--- a/spec/selective/ruby/core/controller_spec.rb
+++ b/spec/selective/ruby/core/controller_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Selective::Ruby::Core::Controller do
+  let(:runner_class) { class_double("runner_class", new: runner) }
   let(:runner) { double("runner", finish: nil, exit_status: 1, framework: 'rspec', framework_version: "1.0", wrapper_version: "1.0") }
-  let(:controller) { dirty_dirty_unprivate_class(described_class).new(runner) }
+  let(:controller) { dirty_dirty_unprivate_class(described_class).new(runner_class, nil) }
 
   let!(:pipe) { Selective::Ruby::Core::NamedPipe.new("/tmp/#{controller.runner_id}_test_2", "/tmp/#{controller.runner_id}_test_1", skip_reset: true) }
   let!(:reverse_pipe) { Selective::Ruby::Core::NamedPipe.new("/tmp/#{controller.runner_id}_test_1", "/tmp/#{controller.runner_id}_test_2", skip_reset: true) }

--- a/spec/selective/ruby/core/init_spec.rb
+++ b/spec/selective/ruby/core/init_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[exec mock_runner] }
 
       it "initializes runner and calls exec" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: false, log: false)
-        expect(mock_runner_class).to have_received(:new).with([])
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_class, [], debug: false, log: false)
         expect(mock_controller).to have_received(:exec)
       end
     end
@@ -24,8 +23,7 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[exec mock_runner --dry-run] }
 
       it "initializes runner with the --dry-run option and calls exec" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: false, log: false)
-        expect(mock_runner_class).to have_received(:new).with(["--dry-run"])
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_class, ["--dry-run"], debug: false, log: false)
         expect(mock_controller).to have_received(:exec)
       end
     end
@@ -34,8 +32,7 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[mock_runner] }
 
       it "initializes runner and calls start" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: false, log: false)
-        expect(mock_runner_class).to have_received(:new).with([])
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_class, [], debug: false, log: false)
         expect(mock_controller).to have_received(:start)
       end
     end
@@ -44,8 +41,7 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[mock_runner --debug] }
 
       it "initializes runner with debug and calls start" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: true, log: false)
-        expect(mock_runner_class).to have_received(:new).with([])
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_class, [], debug: true, log: false)
         expect(mock_controller).to have_received(:start)
       end
     end
@@ -54,8 +50,7 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[mock_runner --log] }
 
       it "initializes runner with debug and calls start" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: false, log: true)
-        expect(mock_runner_class).to have_received(:new).with([])
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_class, [], debug: false, log: true)
         expect(mock_controller).to have_received(:start)
       end
     end
@@ -64,8 +59,7 @@ RSpec.describe Selective::Ruby::Core::Init do
       let(:args) { %w[mock_runner spec/foo/bar_spec.rb] }
 
       it "initializes runner with file path and calls start" do
-        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_instance, debug: false, log: false)
-        expect(mock_runner_class).to have_received(:new).with(["spec/foo/bar_spec.rb"])
+        expect(Selective::Ruby::Core::Controller).to have_received(:new).with(mock_runner_class, ["spec/foo/bar_spec.rb"], debug: false, log: false)
         expect(mock_controller).to have_received(:start)
       end
     end


### PR DESCRIPTION
We now pass the test case callback to the runner when the controller is initialized instead of passing it to the `run_test_cases` method. This is necessary in order to support runners such as RSpec that now use the callback to setup a formatter.