### PR TITLE
Fix quoting bug in build_env.sh by escaping double quotes in JSON output

### DIFF
--- a/lib/bin/build_env.sh
+++ b/lib/bin/build_env.sh
@@ -31,22 +31,26 @@ elif [ -n "$SEMAPHORE" ]; then
   pr_title=$SEMAPHORE_GIT_PR_NAME
 fi
 
+function escape() {
+  echo -n "$1" | sed 's/"/\\"/g'
+}
+
 # Output the JSON
 cat <<EOF
   {
-    "api_key": "$SELECTIVE_API_KEY",
-    "host": "${SELECTIVE_HOST:-wss://app.selective.ci}",
-    "platform": "${SELECTIVE_PLATFORM:-$platform}",
-    "branch": "${SELECTIVE_BRANCH:-$branch}",
-    "pr_title": "${SELECTIVE_PR_TITLE:-$pr_title}",
-    "target_branch": "${SELECTIVE_TARGET_BRANCH:-$target_branch}",
-    "actor": "${SELECTIVE_ACTOR:-$actor}",
-    "sha": "${SELECTIVE_SHA:-$sha}",
-    "run_id": "${SELECTIVE_RUN_ID:-$run_id}",
-    "run_attempt": "${SELECTIVE_RUN_ATTEMPT:-$run_attempt}",
-    "runner_id": "${SELECTIVE_RUNNER_ID:-$runner_id}",
-    "commit_message": "$(git log --format=%s -n 1 $sha)",
-    "committer_name": "$(git show -s --format='%an' -n 1 $sha)",
-    "committer_email": "$(git show -s --format='%ae' -n 1 $sha)"
+    "api_key": "$(escape "${SELECTIVE_API_KEY}")",
+    "host": "$(escape "${SELECTIVE_HOST:-wss://app.selective.ci}")",
+    "platform": "$(escape "${SELECTIVE_PLATFORM:-$platform}")",
+    "branch": "$(escape "${SELECTIVE_BRANCH:-$branch}")",
+    "pr_title": "$(escape "${SELECTIVE_PR_TITLE:-$pr_title}")",
+    "target_branch": "$(escape "${SELECTIVE_TARGET_BRANCH:-$target_branch}")",
+    "actor": "$(escape "${SELECTIVE_ACTOR:-$actor}")",
+    "sha": "$(escape "${SELECTIVE_SHA:-$sha}")",
+    "run_id": "$(escape "${SELECTIVE_RUN_ID:-$run_id}")",
+    "run_attempt": "$(escape "${SELECTIVE_RUN_ATTEMPT:-$run_attempt}")",
+    "runner_id": "$(escape "${SELECTIVE_RUNNER_ID:-$runner_id}")",
+    "commit_message": "$(escape "$(git log --format=%s -n 1 $sha)")",
+    "committer_name": "$(escape "$(git show -s --format='%an' -n 1 $sha)")",
+    "committer_email": "$(escape "$(git show -s --format='%ae' -n 1 $sha)")"
   }
 EOF


### PR DESCRIPTION
We've had a couple of bug reports where quotes in a PR title break our ability to parse the JSON. We've decided to apply this escaping to every value just to be safe and to ensure we don't skip a value that may need it in the future.