### PR TITLE
Add support for Mint

### DIFF
--- a/lib/bin/build_env.sh
+++ b/lib/bin/build_env.sh
@@ -10,6 +10,9 @@ if [ -n "$GITHUB_ACTIONS" ]; then
   run_id=$GITHUB_RUN_ID
   run_attempt=$GITHUB_RUN_ATTEMPT
   runner_id=$SELECTIVE_RUNNER_ID
+  commit_message=$(git log --format=%s -n 1 $sha)
+  committer_name=$(git show -s --format='%an' -n 1 $sha)
+  committer_email=$(git show -s --format='%ae' -n 1 $sha)
 elif [ -n "$CIRCLECI" ]; then
   platform=circleci
   branch=$CIRCLE_BRANCH
@@ -17,6 +20,9 @@ elif [ -n "$CIRCLECI" ]; then
   sha=$CIRCLE_SHA1
   run_attempt=$CIRCLE_BUILD_NUM
   runner_id=$CIRCLE_NODE_INDEX
+  commit_message=$(git log --format=%s -n 1 $sha)
+  committer_name=$(git show -s --format='%an' -n 1 $sha)
+  committer_email=$(git show -s --format='%ae' -n 1 $sha)
 elif [ -n "$SEMAPHORE" ]; then
   platform=semaphore
   branch=${SEMAPHORE_GIT_PR_BRANCH:-$SEMAPHORE_GIT_BRANCH}
@@ -29,6 +35,23 @@ elif [ -n "$SEMAPHORE" ]; then
   run_attempt=1
   runner_id=$SEMAPHORE_JOB_ID
   pr_title=$SEMAPHORE_GIT_PR_NAME
+  commit_message=$(git log --format=%s -n 1 $sha)
+  committer_name=$(git show -s --format='%an' -n 1 $sha)
+  committer_email=$(git show -s --format='%ae' -n 1 $sha)
+elif [ -n "$MINT" ]; then
+  platform=mint
+  branch="${MINT_GIT_REF_NAME}"
+  actor="${MINT_ACTOR}"
+  sha="${MINT_GIT_COMMIT_SHA}"
+  run_id="${MINT_RUN_ID}"
+  run_attempt="${MINT_TASK_ATTEMPT_NUMBER}"
+  runner_id="${MINT_PARALLEL_INDEX}"
+  # Mint does not preserve the .git directory by default to improve the likelihood of cache hits. Instead
+  # of asking git for commit information, then, we rely on the mint/git-clone leaf to populate the necessary
+  # metadata in environment variables.
+  commit_message="${MINT_GIT_COMMIT_SUMMARY}"
+  committer_name="${MINT_GIT_COMMITTER_NAME}"
+  committer_email="${MINT_GIT_COMMITTER_EMAIL}"
 fi
 
 function escape() {
@@ -49,8 +72,8 @@ cat <<EOF
     "run_id": "$(escape "${SELECTIVE_RUN_ID:-$run_id}")",
     "run_attempt": "$(escape "${SELECTIVE_RUN_ATTEMPT:-$run_attempt}")",
     "runner_id": "$(escape "${SELECTIVE_RUNNER_ID:-$runner_id}")",
-    "commit_message": "$(escape "$(git log --format=%s -n 1 $sha)")",
-    "committer_name": "$(escape "$(git show -s --format='%an' -n 1 $sha)")",
-    "committer_email": "$(escape "$(git show -s --format='%ae' -n 1 $sha)")"
+    "commit_message": "$(escape "${SELECTIVE_COMMIT_MESSAGE:-$commit_message}")",
+    "committer_name": "$(escape "${SELECTIVE_COMMITTER_NAME:-$committer_name}")",
+    "committer_email": "$(escape "${SELECTIVE_COMMITTER_EMAIL:-$committer_email}")"
   }
 EOF


### PR DESCRIPTION
With this change, using Selective on [Mint](https://www.rwx.com/mint) will work out of the box without nearly as much configuration of environment variables 🚀 

I believe the API key is the only additional thing that would need specified, but I wasn't sure which fields are and aren't required (for example, we aren't setting `pr_title` and `target_branch` for Mint).