### PR TITLE
Add environment variable handling for RWX platform

### DIFF
--- a/lib/bin/build_env.sh
+++ b/lib/bin/build_env.sh
@@ -52,6 +52,20 @@ elif [ -n "$MINT" ]; then
   commit_message="${MINT_GIT_COMMIT_SUMMARY}"
   committer_name="${MINT_GIT_COMMITTER_NAME}"
   committer_email="${MINT_GIT_COMMITTER_EMAIL}"
+elif [ -n "$RWX" ]; then
+  platform=rwx
+  branch="${RWX_GIT_REF_NAME}"
+  actor="${RWX_ACTOR}"
+  sha="${RWX_GIT_COMMIT_SHA}"
+  run_id="${RWX_RUN_ID}"
+  run_attempt="${RWX_TASK_ATTEMPT_NUMBER}"
+  runner_id="${RWX_PARALLEL_INDEX}"
+  # Mint does not preserve the .git directory by default to improve the likelihood of cache hits. Instead
+  # of asking git for commit information, then, we rely on the mint/git-clone leaf to populate the necessary
+  # metadata in environment variables.
+  commit_message="${RWX_GIT_COMMIT_SUMMARY}"
+  committer_name="${RWX_GIT_COMMITTER_NAME}"
+  committer_email="${RWX_GIT_COMMITTER_EMAIL}"
 fi
 
 function escape() {


### PR DESCRIPTION
RWX rebranded Mint to RWX and on newer version of the git-clone package it no longer uses MINT based env vars.