### PR TITLE
Bump GitHub Actions and add Ruby 3.4 / 4.0 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: "3.4"
           bundler-cache: true
 
       - name: Setup Selective

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,12 @@ jobs:
         ci_node_index: [0, 1, 2, 3]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "4.0"
           bundler-cache: true
 
       - name: Setup Selective
@@ -37,7 +37,7 @@ jobs:
 
       - name: Store logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
-          name: logs
+          name: logs-${{ matrix.ci_node_index }}
           path: ./log/*.log

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "4.0"
           bundler-cache: true
 
       - name: Setup Selective

--- a/.github/workflows/test_all_the_things.yml
+++ b/.github/workflows/test_all_the_things.yml
@@ -16,6 +16,8 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
+          - "4.0"
           - "head"
         runners: [1, 2]
 
@@ -28,7 +30,7 @@ jobs:
       CLONE_PAT: ${{ secrets.CLONE_PAT }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/selective-ruby-core.gemspec
+++ b/selective-ruby-core.gemspec
@@ -43,5 +43,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
+  spec.add_dependency("logger", "~> 1.6")
   spec.add_dependency("zeitwerk", "~> 2.6.12")
 end


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v3 → v6 and `actions/upload-artifact` v3 → v7 in both workflows
- `upload-artifact@v4+` requires unique artifact names per matrix job, so `logs` is now suffixed with `ci_node_index`
- Bump primary CI Ruby from 3.3 to 4.0
- Add Ruby 3.4 and 4.0 to the multi-version matrix in `test_all_the_things.yml`

## Test plan
- [ ] `Ruby` workflow runs cleanly on this PR (checkout v6, upload-artifact v7, Ruby 4.0)
- [ ] Verify each matrix job uploads its own `logs-N` artifact and none collide
- [ ] Manually dispatch `Multi Ruby Matrix` to confirm 3.4 and 4.0 jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)