### PR TITLE
Emit github_repo_full_name and git_provider in run metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-- Add `git_repo_full_name` and `git_provider` to run metadata (GitHub Actions, CircleCI, Semaphore, Buildkite, RWX/Mint). Supports explicit `SELECTIVE_GIT_REPO` / `SELECTIVE_GIT_PROVIDER` overrides and a git-remote fallback. Fields are emitted as empty strings when the repo is not a GitHub repo; the server side is responsible for enforcing presence when billing requires it.
+- Add `git_repo_full_name`, `git_provider`, and `base_sha` to run metadata (GitHub Actions, CircleCI, Semaphore, Buildkite, RWX/Mint). Supports explicit `SELECTIVE_GIT_REPO` / `SELECTIVE_GIT_PROVIDER` / `SELECTIVE_BASE_SHA` overrides and a git-remote fallback for the slug. `base_sha` is extracted from GitHub Actions event payload (both PR and push events) and from Semaphore's `SEMAPHORE_GIT_COMMIT_RANGE`. Fields are emitted as empty strings when unresolvable; the server side is responsible for enforcing presence when billing requires it.
 - Add Buildkite as a recognized CI platform.
 
 ## [0.2.8] - 2025-06-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-- Add `github_repo_full_name` and `git_provider` to run metadata (GitHub Actions, CircleCI, Semaphore, Buildkite, RWX/Mint). Supports explicit `SELECTIVE_GITHUB_REPO` / `SELECTIVE_GIT_PROVIDER` overrides and a git-remote fallback. Fields are emitted as empty strings when the repo is not a GitHub repo; the server side is responsible for enforcing presence when billing requires it.
+- Add `git_repo_full_name` and `git_provider` to run metadata (GitHub Actions, CircleCI, Semaphore, Buildkite, RWX/Mint). Supports explicit `SELECTIVE_GIT_REPO` / `SELECTIVE_GIT_PROVIDER` overrides and a git-remote fallback. Fields are emitted as empty strings when the repo is not a GitHub repo; the server side is responsible for enforcing presence when billing requires it.
 - Add Buildkite as a recognized CI platform.
 
 ## [0.2.8] - 2025-06-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+- Add `github_repo_full_name` and `git_provider` to run metadata (GitHub Actions, CircleCI, Semaphore, Buildkite, RWX/Mint). Supports explicit `SELECTIVE_GITHUB_REPO` / `SELECTIVE_GIT_PROVIDER` overrides and a git-remote fallback. Fields are emitted as empty strings when the repo is not a GitHub repo; the server side is responsible for enforcing presence when billing requires it.
+- Add Buildkite as a recognized CI platform.
 
 ## [0.2.8] - 2025-06-03
 - Update metadata to align with Mint's rename to RWX

--- a/lib/bin/build_env.sh
+++ b/lib/bin/build_env.sh
@@ -1,6 +1,28 @@
 #!/bin/bash
 
-# Detect the platform (only GitHub Actions in this case)
+# Parse an "owner/repo" slug out of a git remote URL (SSH or HTTPS) that points
+# at github.com. Emits an empty string when the URL is not a github.com URL.
+parse_github_slug() {
+  local url="$1"
+  case "$url" in
+    git@github.com:*|git://github.com/*|https://github.com/*|http://github.com/*|ssh://git@github.com/*)
+      echo "$url" | sed -E 's#^(git@|(git|https?|ssh)://(git@)?)github\.com[:/]##; s#\.git/?$##'
+      ;;
+  esac
+}
+
+# Given a git remote URL, classify the provider as github|gitlab|bitbucket or
+# empty when unrecognized. Used for the git_provider hint.
+detect_git_provider_from_url() {
+  local url="$1"
+  case "$url" in
+    *github.com*)    echo "github" ;;
+    *gitlab.com*)    echo "gitlab" ;;
+    *bitbucket.org*) echo "bitbucket" ;;
+  esac
+}
+
+# Detect the platform
 if [ -n "$GITHUB_ACTIONS" ]; then
   platform=github_actions
   branch=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
@@ -13,6 +35,8 @@ if [ -n "$GITHUB_ACTIONS" ]; then
   commit_message=$(git log --format=%s -n 1 $sha)
   committer_name=$(git show -s --format='%an' -n 1 $sha)
   committer_email=$(git show -s --format='%ae' -n 1 $sha)
+  github_repo_full_name=$GITHUB_REPOSITORY
+  git_provider=github
 elif [ -n "$CIRCLECI" ]; then
   platform=circleci
   branch=$CIRCLE_BRANCH
@@ -23,6 +47,19 @@ elif [ -n "$CIRCLECI" ]; then
   commit_message=$(git log --format=%s -n 1 $sha)
   committer_name=$(git show -s --format='%an' -n 1 $sha)
   committer_email=$(git show -s --format='%ae' -n 1 $sha)
+  # CircleCI has no single "slug" env var. Compose from username + reponame.
+  # These work for both GitHub OAuth and GitHub App pipelines. For non-GitHub
+  # pipelines (GitLab, Bitbucket) the same vars exist but we gate on the repo
+  # URL to avoid emitting a non-GitHub slug.
+  if [ -n "$CIRCLE_PROJECT_USERNAME" ] && [ -n "$CIRCLE_PROJECT_REPONAME" ]; then
+    git_provider=$(detect_git_provider_from_url "$CIRCLE_REPOSITORY_URL")
+    if [ "$git_provider" = "github" ] || [ -z "$CIRCLE_REPOSITORY_URL" ]; then
+      github_repo_full_name="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+      # If we fell through the "no repo URL" path, default provider to github
+      # since the slug composition path is specific to GitHub-style owner/repo.
+      [ -z "$git_provider" ] && git_provider=github
+    fi
+  fi
 elif [ -n "$SEMAPHORE" ]; then
   platform=semaphore
   branch=${SEMAPHORE_GIT_PR_BRANCH:-$SEMAPHORE_GIT_BRANCH}
@@ -38,6 +75,30 @@ elif [ -n "$SEMAPHORE" ]; then
   commit_message=$(git log --format=%s -n 1 $sha)
   committer_name=$(git show -s --format='%an' -n 1 $sha)
   committer_email=$(git show -s --format='%ae' -n 1 $sha)
+  git_provider=$SEMAPHORE_GIT_PROVIDER
+  if [ "$git_provider" = "github" ]; then
+    github_repo_full_name=$SEMAPHORE_GIT_REPO_SLUG
+  fi
+elif [ -n "$BUILDKITE" ]; then
+  platform=buildkite
+  branch=$BUILDKITE_BRANCH
+  target_branch=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
+  actor=$BUILDKITE_BUILD_AUTHOR
+  sha=$BUILDKITE_COMMIT
+  run_id=$BUILDKITE_BUILD_ID
+  run_attempt=$BUILDKITE_RETRY_COUNT
+  runner_id=$BUILDKITE_PARALLEL_JOB
+  pr_title=$BUILDKITE_PULL_REQUEST_TITLE
+  commit_message=$BUILDKITE_MESSAGE
+  committer_name=$BUILDKITE_BUILD_AUTHOR
+  committer_email=$BUILDKITE_BUILD_AUTHOR_EMAIL
+  # Buildkite tells us the provider explicitly, and BUILDKITE_REPO is the URL.
+  if [ "$BUILDKITE_PIPELINE_PROVIDER" = "github" ]; then
+    git_provider=github
+    github_repo_full_name=$(parse_github_slug "$BUILDKITE_REPO")
+  else
+    git_provider=$BUILDKITE_PIPELINE_PROVIDER
+  fi
 elif [ -n "$RWX" ]; then
   platform=rwx
   branch="${RWX_GIT_REF_NAME}"
@@ -52,6 +113,13 @@ elif [ -n "$RWX" ]; then
   commit_message="${RWX_GIT_COMMIT_SUMMARY}"
   committer_name="${RWX_GIT_COMMITTER_NAME}"
   committer_email="${RWX_GIT_COMMITTER_EMAIL}"
+  # RWX_GIT_REPOSITORY_NAME is extracted by the git/clone package from whatever
+  # URL was cloned. For non-GitHub hosts this still looks like "owner/repo" but
+  # points elsewhere, so cross-check the URL host before trusting it.
+  git_provider=$(detect_git_provider_from_url "$RWX_GIT_REPOSITORY_URL")
+  if [ "$git_provider" = "github" ]; then
+    github_repo_full_name="${RWX_GIT_REPOSITORY_NAME}"
+  fi
 elif [ -n "$MINT" ]; then
   platform=rwx
   branch="${MINT_GIT_REF_NAME}"
@@ -66,6 +134,27 @@ elif [ -n "$MINT" ]; then
   commit_message="${MINT_GIT_COMMIT_SUMMARY}"
   committer_name="${MINT_GIT_COMMITTER_NAME}"
   committer_email="${MINT_GIT_COMMITTER_EMAIL}"
+  git_provider=$(detect_git_provider_from_url "$MINT_GIT_REPOSITORY_URL")
+  if [ "$git_provider" = "github" ]; then
+    github_repo_full_name="${MINT_GIT_REPOSITORY_NAME}"
+  fi
+fi
+
+# Final fallbacks when we haven't resolved the GitHub slug from a known CI
+# platform. Order:
+#   1. Explicit SELECTIVE_GITHUB_REPO override (always wins; see below).
+#   2. git config --get remote.origin.url on a local checkout.
+if [ -z "$github_repo_full_name" ] && command -v git >/dev/null 2>&1; then
+  origin_url=$(git config --get remote.origin.url 2>/dev/null || true)
+  if [ -n "$origin_url" ]; then
+    parsed_slug=$(parse_github_slug "$origin_url")
+    if [ -n "$parsed_slug" ]; then
+      github_repo_full_name="$parsed_slug"
+      [ -z "$git_provider" ] && git_provider=github
+    elif [ -z "$git_provider" ]; then
+      git_provider=$(detect_git_provider_from_url "$origin_url")
+    fi
+  fi
 fi
 
 function escape() {
@@ -88,6 +177,8 @@ cat <<EOF
     "runner_id": "$(escape "${SELECTIVE_RUNNER_ID:-$runner_id}")",
     "commit_message": "$(escape "${SELECTIVE_COMMIT_MESSAGE:-$commit_message}")",
     "committer_name": "$(escape "${SELECTIVE_COMMITTER_NAME:-$committer_name}")",
-    "committer_email": "$(escape "${SELECTIVE_COMMITTER_EMAIL:-$committer_email}")"
+    "committer_email": "$(escape "${SELECTIVE_COMMITTER_EMAIL:-$committer_email}")",
+    "github_repo_full_name": "$(escape "${SELECTIVE_GITHUB_REPO:-$github_repo_full_name}")",
+    "git_provider": "$(escape "${SELECTIVE_GIT_PROVIDER:-$git_provider}")"
   }
 EOF

--- a/lib/bin/build_env.sh
+++ b/lib/bin/build_env.sh
@@ -37,6 +37,22 @@ if [ -n "$GITHUB_ACTIONS" ]; then
   committer_email=$(git show -s --format='%ae' -n 1 $sha)
   git_repo_full_name=$GITHUB_REPOSITORY
   git_provider=github
+  # Extract base_sha from the webhook event payload GitHub drops at
+  # $GITHUB_EVENT_PATH. Prefer jq when available (handles both push and PR
+  # events); fall back to a grep-based parse for the top-level "before" field
+  # on push events when jq is missing.
+  if [ -f "$GITHUB_EVENT_PATH" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      base_sha=$(jq -r '.pull_request.base.sha // .before // empty' < "$GITHUB_EVENT_PATH" 2>/dev/null)
+    else
+      base_sha=$(grep -o '"before"[[:space:]]*:[[:space:]]*"[^"]*"' "$GITHUB_EVENT_PATH" | head -1 | sed -E 's/.*"[^"]*"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+    fi
+    # GitHub emits all-zero SHAs when the ref was just created and has no prior
+    # state. Treat that as "no base" so the server falls through to head-only.
+    if [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+      base_sha=""
+    fi
+  fi
 elif [ -n "$CIRCLECI" ]; then
   platform=circleci
   branch=$CIRCLE_BRANCH
@@ -78,6 +94,11 @@ elif [ -n "$SEMAPHORE" ]; then
   git_provider=$SEMAPHORE_GIT_PROVIDER
   if [ "$git_provider" = "github" ]; then
     git_repo_full_name=$SEMAPHORE_GIT_REPO_SLUG
+  fi
+  # SEMAPHORE_GIT_COMMIT_RANGE is "<base>...<head>" on push/PR events; take the
+  # left side. It is unset when the build isn't commit-scoped.
+  if [ -n "$SEMAPHORE_GIT_COMMIT_RANGE" ]; then
+    base_sha=$(echo "$SEMAPHORE_GIT_COMMIT_RANGE" | sed -E 's/\.\.\..*//')
   fi
 elif [ -n "$BUILDKITE" ]; then
   platform=buildkite
@@ -172,6 +193,7 @@ cat <<EOF
     "target_branch": "$(escape "${SELECTIVE_TARGET_BRANCH:-$target_branch}")",
     "actor": "$(escape "${SELECTIVE_ACTOR:-$actor}")",
     "sha": "$(escape "${SELECTIVE_SHA:-$sha}")",
+    "base_sha": "$(escape "${SELECTIVE_BASE_SHA:-$base_sha}")",
     "run_id": "$(escape "${SELECTIVE_RUN_ID:-$run_id}")",
     "run_attempt": "$(escape "${SELECTIVE_RUN_ATTEMPT:-$run_attempt}")",
     "runner_id": "$(escape "${SELECTIVE_RUNNER_ID:-$runner_id}")",

--- a/lib/bin/build_env.sh
+++ b/lib/bin/build_env.sh
@@ -35,7 +35,7 @@ if [ -n "$GITHUB_ACTIONS" ]; then
   commit_message=$(git log --format=%s -n 1 $sha)
   committer_name=$(git show -s --format='%an' -n 1 $sha)
   committer_email=$(git show -s --format='%ae' -n 1 $sha)
-  github_repo_full_name=$GITHUB_REPOSITORY
+  git_repo_full_name=$GITHUB_REPOSITORY
   git_provider=github
 elif [ -n "$CIRCLECI" ]; then
   platform=circleci
@@ -54,7 +54,7 @@ elif [ -n "$CIRCLECI" ]; then
   if [ -n "$CIRCLE_PROJECT_USERNAME" ] && [ -n "$CIRCLE_PROJECT_REPONAME" ]; then
     git_provider=$(detect_git_provider_from_url "$CIRCLE_REPOSITORY_URL")
     if [ "$git_provider" = "github" ] || [ -z "$CIRCLE_REPOSITORY_URL" ]; then
-      github_repo_full_name="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+      git_repo_full_name="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
       # If we fell through the "no repo URL" path, default provider to github
       # since the slug composition path is specific to GitHub-style owner/repo.
       [ -z "$git_provider" ] && git_provider=github
@@ -77,7 +77,7 @@ elif [ -n "$SEMAPHORE" ]; then
   committer_email=$(git show -s --format='%ae' -n 1 $sha)
   git_provider=$SEMAPHORE_GIT_PROVIDER
   if [ "$git_provider" = "github" ]; then
-    github_repo_full_name=$SEMAPHORE_GIT_REPO_SLUG
+    git_repo_full_name=$SEMAPHORE_GIT_REPO_SLUG
   fi
 elif [ -n "$BUILDKITE" ]; then
   platform=buildkite
@@ -95,7 +95,7 @@ elif [ -n "$BUILDKITE" ]; then
   # Buildkite tells us the provider explicitly, and BUILDKITE_REPO is the URL.
   if [ "$BUILDKITE_PIPELINE_PROVIDER" = "github" ]; then
     git_provider=github
-    github_repo_full_name=$(parse_github_slug "$BUILDKITE_REPO")
+    git_repo_full_name=$(parse_github_slug "$BUILDKITE_REPO")
   else
     git_provider=$BUILDKITE_PIPELINE_PROVIDER
   fi
@@ -118,7 +118,7 @@ elif [ -n "$RWX" ]; then
   # points elsewhere, so cross-check the URL host before trusting it.
   git_provider=$(detect_git_provider_from_url "$RWX_GIT_REPOSITORY_URL")
   if [ "$git_provider" = "github" ]; then
-    github_repo_full_name="${RWX_GIT_REPOSITORY_NAME}"
+    git_repo_full_name="${RWX_GIT_REPOSITORY_NAME}"
   fi
 elif [ -n "$MINT" ]; then
   platform=rwx
@@ -136,20 +136,20 @@ elif [ -n "$MINT" ]; then
   committer_email="${MINT_GIT_COMMITTER_EMAIL}"
   git_provider=$(detect_git_provider_from_url "$MINT_GIT_REPOSITORY_URL")
   if [ "$git_provider" = "github" ]; then
-    github_repo_full_name="${MINT_GIT_REPOSITORY_NAME}"
+    git_repo_full_name="${MINT_GIT_REPOSITORY_NAME}"
   fi
 fi
 
 # Final fallbacks when we haven't resolved the GitHub slug from a known CI
 # platform. Order:
-#   1. Explicit SELECTIVE_GITHUB_REPO override (always wins; see below).
+#   1. Explicit SELECTIVE_GIT_REPO override (always wins; see below).
 #   2. git config --get remote.origin.url on a local checkout.
-if [ -z "$github_repo_full_name" ] && command -v git >/dev/null 2>&1; then
+if [ -z "$git_repo_full_name" ] && command -v git >/dev/null 2>&1; then
   origin_url=$(git config --get remote.origin.url 2>/dev/null || true)
   if [ -n "$origin_url" ]; then
     parsed_slug=$(parse_github_slug "$origin_url")
     if [ -n "$parsed_slug" ]; then
-      github_repo_full_name="$parsed_slug"
+      git_repo_full_name="$parsed_slug"
       [ -z "$git_provider" ] && git_provider=github
     elif [ -z "$git_provider" ]; then
       git_provider=$(detect_git_provider_from_url "$origin_url")
@@ -178,7 +178,7 @@ cat <<EOF
     "commit_message": "$(escape "${SELECTIVE_COMMIT_MESSAGE:-$commit_message}")",
     "committer_name": "$(escape "${SELECTIVE_COMMITTER_NAME:-$committer_name}")",
     "committer_email": "$(escape "${SELECTIVE_COMMITTER_EMAIL:-$committer_email}")",
-    "github_repo_full_name": "$(escape "${SELECTIVE_GITHUB_REPO:-$github_repo_full_name}")",
+    "git_repo_full_name": "$(escape "${SELECTIVE_GIT_REPO:-$git_repo_full_name}")",
     "git_provider": "$(escape "${SELECTIVE_GIT_PROVIDER:-$git_provider}")"
   }
 EOF

--- a/lib/selective/ruby/core/controller.rb
+++ b/lib/selective/ruby/core/controller.rb
@@ -16,7 +16,10 @@ module Selective
           "platform" => "SELECTIVE_PLATFORM",
           "run_id" => "SELECTIVE_RUN_ID",
           "run_attempt" => "SELECTIVE_RUN_ATTEMPT",
-          "branch" => "SELECTIVE_BRANCH"
+          "branch" => "SELECTIVE_BRANCH",
+          "sha" => "SELECTIVE_SHA",
+          "git_repo_full_name" => "SELECTIVE_GIT_REPO",
+          "git_provider" => "SELECTIVE_GIT_PROVIDER"
         }.freeze
 
         def initialize(runner_class, runner_args, debug: false, log: false)

--- a/spec/bin/build_env_spec.rb
+++ b/spec/bin/build_env_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe "build_env.sh" do
     MINT_TASK_ATTEMPT_NUMBER MINT_PARALLEL_INDEX MINT_GIT_COMMIT_SUMMARY
     MINT_GIT_COMMITTER_NAME MINT_GIT_COMMITTER_EMAIL MINT_GIT_REPOSITORY_NAME
     MINT_GIT_REPOSITORY_URL
+    SELECTIVE_GIT_BRANCH SELECTIVE_GIT_PROVIDER GITHUB_EVENT_PATH
+    SELECTIVE_BASE_SHA SEMAPHORE_GIT_COMMIT_RANGE
   ].freeze
 
   # Run the script with a fresh environment and return parsed JSON output.
@@ -214,6 +216,89 @@ RSpec.describe "build_env.sh" do
       expect(out["git_repo_full_name"]).to eq("")
       expect(out["git_provider"]).to eq("")
       expect(out["platform"]).to eq("")
+    end
+  end
+
+  describe "base_sha detection" do
+    it "parses base_sha from the GHA pull_request event payload via jq" do
+      Dir.mktmpdir do |tmp|
+        event_path = File.join(tmp, "event.json")
+        File.write(event_path, JSON.dump(
+          "pull_request" => { "base" => { "sha" => "basefeedfeed" } }
+        ))
+        env = {
+          "GITHUB_ACTIONS" => "true",
+          "GITHUB_REPOSITORY" => "acme/widgets",
+          "GITHUB_SHA" => "headfeedfeed",
+          "GITHUB_EVENT_PATH" => event_path
+        }
+        out = run_with(env)
+        expect(out["base_sha"]).to eq("basefeedfeed")
+      end
+    end
+
+    it "parses base_sha from the GHA push event's 'before' field" do
+      Dir.mktmpdir do |tmp|
+        event_path = File.join(tmp, "event.json")
+        File.write(event_path, JSON.dump("before" => "beforesha1234", "after" => "headfeedfeed"))
+        env = {
+          "GITHUB_ACTIONS" => "true",
+          "GITHUB_REPOSITORY" => "acme/widgets",
+          "GITHUB_SHA" => "headfeedfeed",
+          "GITHUB_EVENT_PATH" => event_path
+        }
+        out = run_with(env)
+        expect(out["base_sha"]).to eq("beforesha1234")
+      end
+    end
+
+    it "treats the all-zero 'before' SHA as no base" do
+      Dir.mktmpdir do |tmp|
+        event_path = File.join(tmp, "event.json")
+        File.write(event_path, JSON.dump("before" => "0" * 40))
+        env = {
+          "GITHUB_ACTIONS" => "true",
+          "GITHUB_REPOSITORY" => "acme/widgets",
+          "GITHUB_SHA" => "headfeedfeed",
+          "GITHUB_EVENT_PATH" => event_path
+        }
+        out = run_with(env)
+        expect(out["base_sha"]).to eq("")
+      end
+    end
+
+    it "parses base_sha from SEMAPHORE_GIT_COMMIT_RANGE" do
+      env = {
+        "SEMAPHORE" => "true",
+        "SEMAPHORE_GIT_PROVIDER" => "github",
+        "SEMAPHORE_GIT_REPO_SLUG" => "acme/widgets",
+        "SEMAPHORE_GIT_SHA" => "headfeedfeed",
+        "SEMAPHORE_GIT_BRANCH" => "main",
+        "SEMAPHORE_GIT_COMMIT_RANGE" => "basefeedfeed...headfeedfeed"
+      }
+      out = run_with(env)
+      expect(out["base_sha"]).to eq("basefeedfeed")
+    end
+
+    it "lets SELECTIVE_BASE_SHA override everything" do
+      Dir.mktmpdir do |tmp|
+        event_path = File.join(tmp, "event.json")
+        File.write(event_path, JSON.dump("before" => "detectedsha"))
+        env = {
+          "GITHUB_ACTIONS" => "true",
+          "GITHUB_REPOSITORY" => "acme/widgets",
+          "GITHUB_SHA" => "headfeedfeed",
+          "GITHUB_EVENT_PATH" => event_path,
+          "SELECTIVE_BASE_SHA" => "overridesha"
+        }
+        out = run_with(env)
+        expect(out["base_sha"]).to eq("overridesha")
+      end
+    end
+
+    it "emits empty base_sha when no source is available" do
+      out = run_with({})
+      expect(out["base_sha"]).to eq("")
     end
   end
 

--- a/spec/bin/build_env_spec.rb
+++ b/spec/bin/build_env_spec.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "tmpdir"
+
+RSpec.describe "build_env.sh" do
+  SCRIPT = File.expand_path("../../lib/bin/build_env.sh", __dir__)
+
+  # The script inherits the calling environment. RSpec test processes run under
+  # GitHub Actions in CI, which would cause every test to look like a GHA run
+  # unless we scrub the CI-platform env first.
+  PLATFORM_ENV_VARS = %w[
+    GITHUB_ACTIONS CIRCLECI SEMAPHORE BUILDKITE RWX MINT
+    GITHUB_REPOSITORY GITHUB_REF_NAME GITHUB_HEAD_REF GITHUB_BASE_REF
+    GITHUB_ACTOR GITHUB_SHA GITHUB_RUN_ID GITHUB_RUN_ATTEMPT
+    CIRCLE_BRANCH CIRCLE_USERNAME CIRCLE_PR_USERNAME CIRCLE_SHA1
+    CIRCLE_BUILD_NUM CIRCLE_NODE_INDEX CIRCLE_PROJECT_USERNAME
+    CIRCLE_PROJECT_REPONAME CIRCLE_REPOSITORY_URL
+    SEMAPHORE_GIT_BRANCH SEMAPHORE_GIT_PR_BRANCH SEMAPHORE_GIT_COMMITTER
+    SEMAPHORE_GIT_SHA SEMAPHORE_WORKFLOW_ID SEMAPHORE_JOB_ID
+    SEMAPHORE_GIT_PR_NAME SEMAPHORE_GIT_PROVIDER SEMAPHORE_GIT_REPO_SLUG
+    BUILDKITE_BRANCH BUILDKITE_PULL_REQUEST_BASE_BRANCH BUILDKITE_BUILD_AUTHOR
+    BUILDKITE_COMMIT BUILDKITE_BUILD_ID BUILDKITE_RETRY_COUNT
+    BUILDKITE_PARALLEL_JOB BUILDKITE_PULL_REQUEST_TITLE BUILDKITE_MESSAGE
+    BUILDKITE_BUILD_AUTHOR_EMAIL BUILDKITE_PIPELINE_PROVIDER BUILDKITE_REPO
+    RWX_GIT_REF_NAME RWX_ACTOR RWX_GIT_COMMIT_SHA RWX_RUN_ID
+    RWX_TASK_ATTEMPT_NUMBER RWX_PARALLEL_INDEX RWX_GIT_COMMIT_SUMMARY
+    RWX_GIT_COMMITTER_NAME RWX_GIT_COMMITTER_EMAIL RWX_GIT_REPOSITORY_NAME
+    RWX_GIT_REPOSITORY_URL
+    MINT_GIT_REF_NAME MINT_ACTOR MINT_GIT_COMMIT_SHA MINT_RUN_ID
+    MINT_TASK_ATTEMPT_NUMBER MINT_PARALLEL_INDEX MINT_GIT_COMMIT_SUMMARY
+    MINT_GIT_COMMITTER_NAME MINT_GIT_COMMITTER_EMAIL MINT_GIT_REPOSITORY_NAME
+    MINT_GIT_REPOSITORY_URL
+    SELECTIVE_GITHUB_REPO SELECTIVE_GIT_PROVIDER
+  ].freeze
+
+  # Run the script with a fresh environment and return parsed JSON output.
+  def run_with(env)
+    scrubbed = PLATFORM_ENV_VARS.each_with_object({}) { |k, h| h[k] = nil }
+    # Disable git shell-outs by pointing at an empty temp dir so the fallback
+    # branches are deterministic.
+    Dir.mktmpdir do |tmp|
+      full_env = scrubbed.merge(env).merge("PWD" => tmp)
+      stdout, _stderr, status = Open3.capture3(full_env, "bash", SCRIPT, chdir: tmp)
+      raise "build_env.sh failed: #{stdout}" unless status.success?
+      JSON.parse(stdout)
+    end
+  end
+
+  describe "github_repo_full_name detection" do
+    it "reads GITHUB_REPOSITORY on GitHub Actions" do
+      env = {
+        "GITHUB_ACTIONS" => "true",
+        "GITHUB_REPOSITORY" => "selectiveci/selective-ruby-core",
+        "GITHUB_SHA" => "abc123",
+        "GITHUB_REF_NAME" => "main"
+      }
+      out = run_with(env)
+      expect(out["platform"]).to eq("github_actions")
+      expect(out["github_repo_full_name"]).to eq("selectiveci/selective-ruby-core")
+      expect(out["git_provider"]).to eq("github")
+    end
+
+    it "composes owner/repo from CircleCI env vars" do
+      env = {
+        "CIRCLECI" => "true",
+        "CIRCLE_PROJECT_USERNAME" => "acme",
+        "CIRCLE_PROJECT_REPONAME" => "widgets",
+        "CIRCLE_REPOSITORY_URL" => "git@github.com:acme/widgets.git",
+        "CIRCLE_SHA1" => "abc123"
+      }
+      out = run_with(env)
+      expect(out["platform"]).to eq("circleci")
+      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_provider"]).to eq("github")
+    end
+
+    it "does not emit a slug for non-GitHub CircleCI pipelines" do
+      env = {
+        "CIRCLECI" => "true",
+        "CIRCLE_PROJECT_USERNAME" => "acme",
+        "CIRCLE_PROJECT_REPONAME" => "widgets",
+        "CIRCLE_REPOSITORY_URL" => "git@bitbucket.org:acme/widgets.git",
+        "CIRCLE_SHA1" => "abc123"
+      }
+      out = run_with(env)
+      expect(out["github_repo_full_name"]).to eq("")
+      expect(out["git_provider"]).to eq("bitbucket")
+    end
+
+    it "reads SEMAPHORE_GIT_REPO_SLUG when the provider is github" do
+      env = {
+        "SEMAPHORE" => "true",
+        "SEMAPHORE_GIT_PROVIDER" => "github",
+        "SEMAPHORE_GIT_REPO_SLUG" => "acme/widgets",
+        "SEMAPHORE_GIT_SHA" => "abc123",
+        "SEMAPHORE_GIT_BRANCH" => "main",
+        "SEMAPHORE_WORKFLOW_ID" => "wf1",
+        "SEMAPHORE_JOB_ID" => "job1"
+      }
+      out = run_with(env)
+      expect(out["platform"]).to eq("semaphore")
+      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_provider"]).to eq("github")
+    end
+
+    it "does not emit a slug for Semaphore + Bitbucket" do
+      env = {
+        "SEMAPHORE" => "true",
+        "SEMAPHORE_GIT_PROVIDER" => "bitbucket",
+        "SEMAPHORE_GIT_REPO_SLUG" => "acme/widgets",
+        "SEMAPHORE_GIT_SHA" => "abc123",
+        "SEMAPHORE_GIT_BRANCH" => "main"
+      }
+      out = run_with(env)
+      expect(out["github_repo_full_name"]).to eq("")
+      expect(out["git_provider"]).to eq("bitbucket")
+    end
+
+    it "parses BUILDKITE_REPO for github pipelines" do
+      env = {
+        "BUILDKITE" => "true",
+        "BUILDKITE_PIPELINE_PROVIDER" => "github",
+        "BUILDKITE_REPO" => "git@github.com:acme/widgets.git",
+        "BUILDKITE_COMMIT" => "abc123",
+        "BUILDKITE_BRANCH" => "main"
+      }
+      out = run_with(env)
+      expect(out["platform"]).to eq("buildkite")
+      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_provider"]).to eq("github")
+    end
+
+    it "parses HTTPS variants of BUILDKITE_REPO" do
+      env = {
+        "BUILDKITE" => "true",
+        "BUILDKITE_PIPELINE_PROVIDER" => "github",
+        "BUILDKITE_REPO" => "https://github.com/acme/widgets.git",
+        "BUILDKITE_COMMIT" => "abc123"
+      }
+      out = run_with(env)
+      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+    end
+
+    it "does not emit a slug for non-github Buildkite pipelines" do
+      env = {
+        "BUILDKITE" => "true",
+        "BUILDKITE_PIPELINE_PROVIDER" => "gitlab",
+        "BUILDKITE_REPO" => "git@gitlab.com:acme/widgets.git",
+        "BUILDKITE_COMMIT" => "abc123"
+      }
+      out = run_with(env)
+      expect(out["github_repo_full_name"]).to eq("")
+      expect(out["git_provider"]).to eq("gitlab")
+    end
+
+    it "uses RWX_GIT_REPOSITORY_NAME when the URL is github" do
+      env = {
+        "RWX" => "true",
+        "RWX_GIT_REPOSITORY_NAME" => "acme/widgets",
+        "RWX_GIT_REPOSITORY_URL" => "https://github.com/acme/widgets.git",
+        "RWX_GIT_COMMIT_SHA" => "abc123",
+        "RWX_GIT_REF_NAME" => "main"
+      }
+      out = run_with(env)
+      expect(out["platform"]).to eq("rwx")
+      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_provider"]).to eq("github")
+    end
+
+    it "ignores RWX_GIT_REPOSITORY_NAME when the URL is not github" do
+      env = {
+        "RWX" => "true",
+        "RWX_GIT_REPOSITORY_NAME" => "acme/widgets",
+        "RWX_GIT_REPOSITORY_URL" => "https://gitlab.com/acme/widgets.git",
+        "RWX_GIT_COMMIT_SHA" => "abc123"
+      }
+      out = run_with(env)
+      expect(out["github_repo_full_name"]).to eq("")
+      expect(out["git_provider"]).to eq("gitlab")
+    end
+
+    it "honors MINT legacy env vars when RWX is absent" do
+      env = {
+        "MINT" => "true",
+        "MINT_GIT_REPOSITORY_NAME" => "acme/widgets",
+        "MINT_GIT_REPOSITORY_URL" => "git@github.com:acme/widgets.git",
+        "MINT_GIT_COMMIT_SHA" => "abc123"
+      }
+      out = run_with(env)
+      expect(out["platform"]).to eq("rwx")
+      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_provider"]).to eq("github")
+    end
+
+    it "lets SELECTIVE_GITHUB_REPO override everything" do
+      env = {
+        "GITHUB_ACTIONS" => "true",
+        "GITHUB_REPOSITORY" => "detected/repo",
+        "SELECTIVE_GITHUB_REPO" => "override/repo",
+        "GITHUB_SHA" => "abc123"
+      }
+      out = run_with(env)
+      expect(out["github_repo_full_name"]).to eq("override/repo")
+    end
+
+    it "emits empty strings when nothing is detectable and no CI platform is set" do
+      out = run_with({})
+      expect(out["github_repo_full_name"]).to eq("")
+      expect(out["git_provider"]).to eq("")
+      expect(out["platform"]).to eq("")
+    end
+  end
+
+  describe "SSH and HTTPS URL parsing" do
+    {
+      "git@github.com:acme/widgets.git"     => "acme/widgets",
+      "git@github.com:acme/widgets"         => "acme/widgets",
+      "https://github.com/acme/widgets.git" => "acme/widgets",
+      "https://github.com/acme/widgets"     => "acme/widgets",
+      "http://github.com/acme/widgets.git"  => "acme/widgets",
+      "ssh://git@github.com/acme/widgets.git" => "acme/widgets",
+      "git://github.com/acme/widgets.git"   => "acme/widgets"
+    }.each do |url, expected|
+      it "parses #{url}" do
+        env = {
+          "BUILDKITE" => "true",
+          "BUILDKITE_PIPELINE_PROVIDER" => "github",
+          "BUILDKITE_REPO" => url,
+          "BUILDKITE_COMMIT" => "abc"
+        }
+        out = run_with(env)
+        expect(out["github_repo_full_name"]).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/bin/build_env_spec.rb
+++ b/spec/bin/build_env_spec.rb
@@ -32,12 +32,16 @@ RSpec.describe "build_env.sh" do
     MINT_TASK_ATTEMPT_NUMBER MINT_PARALLEL_INDEX MINT_GIT_COMMIT_SUMMARY
     MINT_GIT_COMMITTER_NAME MINT_GIT_COMMITTER_EMAIL MINT_GIT_REPOSITORY_NAME
     MINT_GIT_REPOSITORY_URL
-    SELECTIVE_GITHUB_REPO SELECTIVE_GIT_PROVIDER
   ].freeze
 
   # Run the script with a fresh environment and return parsed JSON output.
   def run_with(env)
-    scrubbed = PLATFORM_ENV_VARS.each_with_object({}) { |k, h| h[k] = nil }
+    # Scrub everything the build_env.sh script looks at: platform detection
+    # vars above, plus every SELECTIVE_* override so the caller's shell
+    # environment (e.g. a loaded .env) can't bleed into the test.
+    scrubbed = {}
+    PLATFORM_ENV_VARS.each { |k| scrubbed[k] = nil }
+    ENV.keys.grep(/\ASELECTIVE_/).each { |k| scrubbed[k] = nil }
     # Disable git shell-outs by pointing at an empty temp dir so the fallback
     # branches are deterministic.
     Dir.mktmpdir do |tmp|
@@ -48,7 +52,7 @@ RSpec.describe "build_env.sh" do
     end
   end
 
-  describe "github_repo_full_name detection" do
+  describe "git_repo_full_name detection" do
     it "reads GITHUB_REPOSITORY on GitHub Actions" do
       env = {
         "GITHUB_ACTIONS" => "true",
@@ -58,7 +62,7 @@ RSpec.describe "build_env.sh" do
       }
       out = run_with(env)
       expect(out["platform"]).to eq("github_actions")
-      expect(out["github_repo_full_name"]).to eq("selectiveci/selective-ruby-core")
+      expect(out["git_repo_full_name"]).to eq("selectiveci/selective-ruby-core")
       expect(out["git_provider"]).to eq("github")
     end
 
@@ -72,7 +76,7 @@ RSpec.describe "build_env.sh" do
       }
       out = run_with(env)
       expect(out["platform"]).to eq("circleci")
-      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_repo_full_name"]).to eq("acme/widgets")
       expect(out["git_provider"]).to eq("github")
     end
 
@@ -85,7 +89,7 @@ RSpec.describe "build_env.sh" do
         "CIRCLE_SHA1" => "abc123"
       }
       out = run_with(env)
-      expect(out["github_repo_full_name"]).to eq("")
+      expect(out["git_repo_full_name"]).to eq("")
       expect(out["git_provider"]).to eq("bitbucket")
     end
 
@@ -101,7 +105,7 @@ RSpec.describe "build_env.sh" do
       }
       out = run_with(env)
       expect(out["platform"]).to eq("semaphore")
-      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_repo_full_name"]).to eq("acme/widgets")
       expect(out["git_provider"]).to eq("github")
     end
 
@@ -114,7 +118,7 @@ RSpec.describe "build_env.sh" do
         "SEMAPHORE_GIT_BRANCH" => "main"
       }
       out = run_with(env)
-      expect(out["github_repo_full_name"]).to eq("")
+      expect(out["git_repo_full_name"]).to eq("")
       expect(out["git_provider"]).to eq("bitbucket")
     end
 
@@ -128,7 +132,7 @@ RSpec.describe "build_env.sh" do
       }
       out = run_with(env)
       expect(out["platform"]).to eq("buildkite")
-      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_repo_full_name"]).to eq("acme/widgets")
       expect(out["git_provider"]).to eq("github")
     end
 
@@ -140,7 +144,7 @@ RSpec.describe "build_env.sh" do
         "BUILDKITE_COMMIT" => "abc123"
       }
       out = run_with(env)
-      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_repo_full_name"]).to eq("acme/widgets")
     end
 
     it "does not emit a slug for non-github Buildkite pipelines" do
@@ -151,7 +155,7 @@ RSpec.describe "build_env.sh" do
         "BUILDKITE_COMMIT" => "abc123"
       }
       out = run_with(env)
-      expect(out["github_repo_full_name"]).to eq("")
+      expect(out["git_repo_full_name"]).to eq("")
       expect(out["git_provider"]).to eq("gitlab")
     end
 
@@ -165,7 +169,7 @@ RSpec.describe "build_env.sh" do
       }
       out = run_with(env)
       expect(out["platform"]).to eq("rwx")
-      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_repo_full_name"]).to eq("acme/widgets")
       expect(out["git_provider"]).to eq("github")
     end
 
@@ -177,7 +181,7 @@ RSpec.describe "build_env.sh" do
         "RWX_GIT_COMMIT_SHA" => "abc123"
       }
       out = run_with(env)
-      expect(out["github_repo_full_name"]).to eq("")
+      expect(out["git_repo_full_name"]).to eq("")
       expect(out["git_provider"]).to eq("gitlab")
     end
 
@@ -190,24 +194,24 @@ RSpec.describe "build_env.sh" do
       }
       out = run_with(env)
       expect(out["platform"]).to eq("rwx")
-      expect(out["github_repo_full_name"]).to eq("acme/widgets")
+      expect(out["git_repo_full_name"]).to eq("acme/widgets")
       expect(out["git_provider"]).to eq("github")
     end
 
-    it "lets SELECTIVE_GITHUB_REPO override everything" do
+    it "lets SELECTIVE_GIT_REPO override everything" do
       env = {
         "GITHUB_ACTIONS" => "true",
         "GITHUB_REPOSITORY" => "detected/repo",
-        "SELECTIVE_GITHUB_REPO" => "override/repo",
+        "SELECTIVE_GIT_REPO" => "override/repo",
         "GITHUB_SHA" => "abc123"
       }
       out = run_with(env)
-      expect(out["github_repo_full_name"]).to eq("override/repo")
+      expect(out["git_repo_full_name"]).to eq("override/repo")
     end
 
     it "emits empty strings when nothing is detectable and no CI platform is set" do
       out = run_with({})
-      expect(out["github_repo_full_name"]).to eq("")
+      expect(out["git_repo_full_name"]).to eq("")
       expect(out["git_provider"]).to eq("")
       expect(out["platform"]).to eq("")
     end
@@ -231,7 +235,7 @@ RSpec.describe "build_env.sh" do
           "BUILDKITE_COMMIT" => "abc"
         }
         out = run_with(env)
-        expect(out["github_repo_full_name"]).to eq(expected)
+        expect(out["git_repo_full_name"]).to eq(expected)
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds `github_repo_full_name` and `git_provider` to the run metadata emitted by `build_env.sh`, so the Selective server can look up the GitHub App installation for a run and resolve committer identities via the GitHub Compare API.

These fields are **never required** by the client. Free-plan orgs may not have GitHub connected at all. Enforcement of presence happens server-side and only applies to paid-plan runs.

## Per-platform detection

| Platform | Source | Gating |
|---|---|---|
| GitHub Actions | `GITHUB_REPOSITORY` | always GitHub |
| CircleCI | `CIRCLE_PROJECT_USERNAME` + `CIRCLE_PROJECT_REPONAME` | gated on `CIRCLE_REPOSITORY_URL` pointing at github.com |
| Semaphore | `SEMAPHORE_GIT_REPO_SLUG` | gated on `SEMAPHORE_GIT_PROVIDER == "github"` |
| **Buildkite (new)** | parsed from `BUILDKITE_REPO` (SSH or HTTPS) | gated on `BUILDKITE_PIPELINE_PROVIDER == "github"` |
| RWX / Mint | `RWX_GIT_REPOSITORY_NAME` / `MINT_GIT_REPOSITORY_NAME` | cross-checked against `*_GIT_REPOSITORY_URL` host |

### Fallbacks

1. **`SELECTIVE_GITHUB_REPO`** env var — explicit override, always wins. Covers Jenkins, self-hosted runners, or any platform we haven't mapped.
2. **`git config --get remote.origin.url`** — when a checkout is present and no platform detection succeeded.

Both fallbacks parse through the same URL regex that handles SSH (`git@github.com:owner/repo.git`), HTTPS (`https://github.com/owner/repo.git`), legacy `git://`, and `ssh://` forms. `.git` suffix is stripped.

## `git_provider` hint

Emits `github`, `gitlab`, `bitbucket`, or empty string. Useful telemetry for deciding when to expand support to non-GitHub Git hosts. Also gates the client from emitting a non-GitHub slug into a GitHub-only server pathway.

## Non-goals

- Non-GitHub Git hosts are not supported server-side yet; this PR only adds the detection hook so future work is zero-code on the client.
- Does not change any existing fields. Pure additive.
- Does not change `REQUIRED_CONFIGURATION` — the new fields are optional.

## Testing

New `spec/bin/build_env_spec.rb` (20 examples, all passing) exercises:

- Per-platform happy paths (GHA, CircleCI, Semaphore, Buildkite, RWX, MINT-legacy).
- Negative cases: CircleCI/Bitbucket, Semaphore/Bitbucket, Buildkite/GitLab, RWX/GitLab.
- `SELECTIVE_GITHUB_REPO` override precedence.
- Empty-environment default (emits empty strings).
- SSH/HTTPS/git://ssh:// URL parsing variants.

```
20 examples, 0 failures
```

Full suite still green (21 examples total — 20 new + 1 pre-existing `#validate_build_env` test).

## Server-side contract (for reference)

- Free plan: `github_repo_full_name` absent → accept run, skip metering.
- Free plan: present → attempt metering if installation linked; otherwise skip.
- Paid plan: absent → reject with `github_repo_required`.
- Paid plan: present but no installation linked → reject with `no_github_app_installed`.

Background doc: `selective/docs/github-repo-detection.md`.
